### PR TITLE
Display the correct paths when using the log.Lshortfile or log.Llongfile flags

### DIFF
--- a/const.go
+++ b/const.go
@@ -2,7 +2,7 @@ package logger
 
 const stdName = "std"
 
-const calldepth = 2
+const calldepth = 3
 
 const (
 	fatalLevel = iota

--- a/logger_test.go
+++ b/logger_test.go
@@ -392,6 +392,42 @@ func TestLogger_SetFlags(t *testing.T) {
 	}
 }
 
+func TestLogger_CallDepth(t *testing.T) {
+	tests := []struct {
+		name    string
+		logName string
+		flags   int
+		want    string
+	}{
+		{
+			name:    "Standar",
+			logName: "std",
+			flags:   log.Lshortfile,
+			want:    "logger_test.go",
+		},
+		{
+			name:    "Not Standar",
+			logName: "not",
+			flags:   log.Lshortfile,
+			want:    "logger_test.go",
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+
+		t.Run(test.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			l := New(test.logName, DEBUG, output)
+			l.SetFlags(test.flags)
+			l.Print("Calldepth path test")
+
+			if got := output.String(); !strings.HasPrefix(got, test.want) {
+				t.Errorf("Logger.Print() = %v, want to start with %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestLogger_Error(t *testing.T) { // nolint:dupl
 	type args struct {
 		msg []interface{}

--- a/std_test.go
+++ b/std_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -142,6 +143,21 @@ func TestStd_SetFlags(t *testing.T) {
 	if !reflect.DeepEqual(std.flag, flags) {
 		t.Errorf("Logger.SetOutput() = %d, want %d", std.flag, flags)
 	}
+}
+
+func TestStdCallDepth(t *testing.T) {
+	output := new(bytes.Buffer)
+
+	SetFlags(log.Lshortfile)
+	SetOutput(output)
+
+	Print("Calldepth path test")
+
+	if got := output.String(); !strings.HasPrefix(got, "std.go") {
+		t.Errorf("Logger.Print() = %v, want to start with std.go", got)
+	}
+
+	output.Reset()
 }
 
 func TestStdErrorAndErrorf(t *testing.T) {


### PR DESCRIPTION
Hi @savsgio!

The paths displayed when using the `log.Lshortfile` or `log.Llongfile` flags are wrong because of the call depth setting for the logging library. You get the file path from the go-logger package not the place where you actually calling the logger.

The solution is trivial, just bumped the `calldepth` from 2 to 3, to account for the additional wrapping of the log package in go-logger.

### Example
Current output when using those flags with the `std` logger - the file and line number from the package where `log` instance is called:
```
[...]/go-logger/logger.go:190: - Calldepth path test
```
Expected output - the file and line number where the logger is actually called:
```
[...]go-logger/std.go:83: - Calldepth path test
```

Looking forward for your feedback or seeing it merged if OK. 😄 

Thanks!